### PR TITLE
Fix SetOtherUserGainForThisConnection

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Please see [Install package](INSTALL.md).
 1. For each User that will be connecting to the Space: create a JSON Web Token (JWT).  The JWT is a compressed binary blob with info about the App Space and the User's publicly visible name (aka optional User ID).  Note: since the User's publicly visible name is optional it is technically possible to use a single JWT for all Users in the Space, however then all HiFi peers' `IncomingAudioAPIData` will have unique `visitHashID` but the same `providedUserID`.
 1. In the Unity project:
     1. Add **com.endel.nativewebsocket** package via git URL: https://github.com/endel/NativeWebSocket.git#upm
-    1. Add Highfidelity's modified **com.unity.webrtc** package via git URL: https://github.com/highfidelity/com.unity.webrtc.git
+    1. Add Highfidelity's modified **com.unity.webrtc** package via git URL: https://github.com/highfidelity/com.unity.webrtc.git#2.4.0-directAudio
     1. Add this **com.highfidelity.spatialized-audio** package.
     1. Create a HiFi.HiFiCommunicator for the User.
     1. Set the `HiFiCommunicator.SignalingServiceUrl` to `wss://api.highfidelity.com:8001/`.

--- a/Runtime/HiFiAudioAPIData.cs
+++ b/Runtime/HiFiAudioAPIData.cs
@@ -181,7 +181,7 @@ public class OutgoingAudioAPIData {
     /// <remarks>
     /// This is a map between visitIdHash and custom gain setting: { visitIdhash : gain, ... }
     /// The value of gain is in range [0,100] with a default value of 1.
-    /// Higher gain makes that Peer louder, lower gain quieter.  A gain of 0 will silence
+    /// Higher gain makes the Peer louder, lower gain quieter.  A gain of 0 will silence
     /// the Peer in the mixed audio sent from the server to the User.
     /// </remarks>
     public Dictionary<string, float> otherUserGains;

--- a/Runtime/HiFiAudioAPIData.cs
+++ b/Runtime/HiFiAudioAPIData.cs
@@ -179,10 +179,11 @@ public class OutgoingAudioAPIData {
     /// Per Peer gain adjustments the server should apply when mixing audio for this User.
     /// </summary>
     /// <remarks>
-    /// This is a map between visitIdHash and custom gain setting: { visitIdhash : gain, ... }
-    /// The value of gain is in range [0,100] with a default value of 1.
-    /// Higher gain makes the Peer louder, lower gain quieter.  A gain of 0 will silence
-    /// the Peer in the mixed audio sent from the server to the User.
+    /// This is a map between visitIdHash and custom gain setting:
+    ///   { visitIdhash : gain, ... }
+    /// The value of gain is in range [0,10] with a default value of 1.  Higher
+    /// gain makes the Peer louder, lower gain quieter.  A gain of 0 will
+    /// silence the Peer in the mixed audio sent from the server to the User.
     /// </remarks>
     public Dictionary<string, float> otherUserGains;
 
@@ -201,7 +202,7 @@ public class OutgoingAudioAPIData {
     }
 
     /// <summary>
-    /// Make a deep copy of this OutgoingAudioAPIData.
+    /// Return a deep copy of this OutgoingAudioAPIData.
     /// </summary>
     public OutgoingAudioAPIData DeepCopy() {
         OutgoingAudioAPIData other = new OutgoingAudioAPIData();
@@ -211,8 +212,6 @@ public class OutgoingAudioAPIData {
         other.hiFiGain = hiFiGain;
         other.userAttenuation = userAttenuation;
         other.userRolloff = userRolloff;
-
-        other.otherUserGains.Clear();
         foreach (string key in otherUserGains.Keys) {
             other.otherUserGains.Add(key, otherUserGains[key]);
         }

--- a/Runtime/HiFiAudioAPIData.cs
+++ b/Runtime/HiFiAudioAPIData.cs
@@ -23,11 +23,13 @@ public class AudioAPIDataChanges {
     public float? g; // gain
     public float? a; // attenutation
     public float? r; // rolloff
+    public Dictionary<string, float> V; // map of gains for other Peer aduio { visitIdHash : gain, ... }
 
     public bool IsEmpty() {
         return x == null && y == null && z == null
             && W == null && X == null && Y == null && Z == null
-            && T == null && g == null && a == null && r == null;
+            && T == null && g == null && a == null && r == null
+            && V == null;
     }
 
     public string ToWireFormattedJsonString() {
@@ -73,12 +75,20 @@ public class AudioAPIDataChanges {
         if (r.HasValue) {
             obj["r"] = r.Value;
         }
+
+        if (V != null) {
+            JSONNode custom_gains = new JSONObject();
+            foreach (KeyValuePair<string, float> kvp in V) {
+                custom_gains[kvp.Key] = kvp.Value;
+            }
+            obj["V"] = custom_gains;
+        }
         return obj.ToString();
     }
 }
 
 /// <summary name="OutgoingAudioAPIData">
-/// Data sent to HiFi Spatial Audio Service.
+/// User specific data sent to HiFi Spatial Audio Service.
 /// </summary>
 /// <seealso cref="IncomingAudioAPIData"/>
 public class OutgoingAudioAPIData {
@@ -117,7 +127,7 @@ public class OutgoingAudioAPIData {
     public float volumeThreshold;
 
     /// <summary>
-    /// Gain (loudness) (range = [0,1]) for user's audio in the HiFi Spatial Audio Space.
+    /// Gain (loudness) (range = [0,1]) for User's audio in the HiFi Spatial Audio Space.
     /// </summary>
     /// <remarks>
     /// Gain ranges from 0.0 (mute) to 1.0 (full volume strength).
@@ -165,6 +175,17 @@ public class OutgoingAudioAPIData {
     /// <seealso cref="userAttenuation"/>
     public float userRolloff;
 
+    /// <summary name="otherUserGains">
+    /// Per Peer gain adjustments the server should apply when mixing audio for this User.
+    /// </summary>
+    /// <remarks>
+    /// This is a map between visitIdHash and custom gain setting: { visitIdhash : gain, ... }
+    /// The value of gain is in range [0,100] with a default value of 1.
+    /// Higher gain makes that Peer louder, lower gain quieter.  A gain of 0 will silence
+    /// the Peer in the mixed audio sent from the server to the User.
+    /// </remarks>
+    public Dictionary<string, float> otherUserGains;
+
     public OutgoingAudioAPIData() {
         position = new Vector3(0.0f, 0.0f, 0.0f);
         orientation = new Quaternion(0.0f, 0.0f, 0.0f, 1.0f);
@@ -176,6 +197,7 @@ public class OutgoingAudioAPIData {
         hiFiGain = DEFAULT_HIFI_GAIN;
         userAttenuation = DEFAULT_USER_ATTENUATION;;
         userRolloff = DEFAULT_USER_ROLLOFF;
+        otherUserGains = new Dictionary<string, float>();
     }
 
     /// <summary>
@@ -189,6 +211,11 @@ public class OutgoingAudioAPIData {
         other.hiFiGain = hiFiGain;
         other.userAttenuation = userAttenuation;
         other.userRolloff = userRolloff;
+
+        other.otherUserGains.Clear();
+        foreach (string key in otherUserGains.Keys) {
+            other.otherUserGains.Add(key, otherUserGains[key]);
+        }
         return other;
     }
 
@@ -258,6 +285,35 @@ public class OutgoingAudioAPIData {
             changes.r = other.userRolloff;
             userRolloff = other.userRolloff;
         }
+
+        Dictionary<string, float> V = new Dictionary<string, float>();
+        const float DEFAULT_GAIN = 1.0f;
+        foreach (KeyValuePair<string, float> kvp in other.otherUserGains) {
+            string key = kvp.Key;
+            float gain = kvp.Value;
+            if (otherUserGains.ContainsKey(key)) {
+                // an existing gain override is changing
+                if (gain != otherUserGains[key]) {
+                    V[key] = gain;
+                    if (gain == DEFAULT_GAIN) {
+                        // overrides at default level can be removed from tracking
+                        otherUserGains.Remove(key);
+                    } else {
+                        otherUserGains[key] = gain;
+                    }
+                }
+            } else if (gain != DEFAULT_GAIN) {
+                // a gain override is being added
+                V[key] = gain;
+                otherUserGains[key] = gain;
+            }
+        }
+        // TODO: when peers are deleted we should check for, and clear out,
+        // corresponding entries in otherUserGains.
+        if (V.Count > 0) {
+            changes.V = V;
+        }
+
         return changes;
     }
 }
@@ -282,7 +338,7 @@ public class IncomingAudioAPIData : OutgoingAudioAPIData {
     /// <remarks>
     /// A unique public identifier for the User's session.
     /// </remarks>
-    public string hashedVisitID;
+    public string visitIdHash;
 
     /// <summary>
     /// True if User is streaming stereo input to server.
@@ -290,13 +346,13 @@ public class IncomingAudioAPIData : OutgoingAudioAPIData {
     public bool isStereo;
 
     /// <summary>
-    /// The current volume of the user in decibels.
+    /// The current volume of the User in decibels.
     /// </summary>
     public float volumeDecibels;
 
     public IncomingAudioAPIData() : base() {
         providedUserID = "";
-        hashedVisitID = "";
+        visitIdHash = "";
         isStereo = false;
         volumeDecibels = 0.0f;
     }
@@ -311,7 +367,7 @@ public class IncomingAudioAPIData : OutgoingAudioAPIData {
         other.userRolloff = userRolloff;
 
         other.providedUserID = providedUserID;
-        other.hashedVisitID = hashedVisitID;
+        other.visitIdHash = visitIdHash;
         other.isStereo = isStereo;
         other.volumeDecibels = volumeDecibels;
         return other;
@@ -330,7 +386,7 @@ public class IncomingAudioAPIData : OutgoingAudioAPIData {
     public bool ApplyWireFormattedJson(JSONNode obj) {
         // the key mappings are:
         //   J = providedUserID
-        //   e = hashedVisitID
+        //   e = visitIdHash
         //   s = isStereo
         //   v = volumeDecibels
         //   x = position.x
@@ -347,8 +403,8 @@ public class IncomingAudioAPIData : OutgoingAudioAPIData {
             if (kvp.Key == "J" && providedUserID != kvp.Value) {
                 providedUserID = kvp.Value;
                 somethingChanged = true;
-            } else if (kvp.Key == "e" && hashedVisitID != kvp.Value) {
-                hashedVisitID = kvp.Value;
+            } else if (kvp.Key == "e" && visitIdHash != kvp.Value) {
+                visitIdHash = kvp.Value;
                 somethingChanged = true;
             } else if (kvp.Key == "e" && isStereo != kvp.Value) {
                 isStereo = kvp.Value;
@@ -409,7 +465,7 @@ public class IncomingAudioAPIData : OutgoingAudioAPIData {
     public string ToWireFormattedJsonString() {
         // the key mappings are:
         //   J = providedUserID
-        //   e = hashedVisitID
+        //   e = visitIdHash
         //   s = isStereo
         //   v = volumeDecibels
         //   x = position.x
@@ -421,7 +477,7 @@ public class IncomingAudioAPIData : OutgoingAudioAPIData {
         //   Z = orientation.z
         JSONNode obj = new JSONObject();
         obj["J"] = providedUserID;
-        obj["e"] = hashedVisitID;
+        obj["e"] = visitIdHash;
         obj["s"] = isStereo;
         obj["v"] = volumeDecibels;
         obj["x"] = position.x;

--- a/Runtime/HiFiCommunicator.cs
+++ b/Runtime/HiFiCommunicator.cs
@@ -18,74 +18,90 @@ using Ravi;
 
 namespace HiFi {
 
-public struct HiFiMixerInfo {
-    public string buildNumber;
-    public string buildType;
-    public string buildVersion;
-    public string visitId;
-    public string visitIdHash;
-    public string userId;
+public class HiFiMixerInfo {
+    public string buildNumber = "unknown";
+    public string buildType = "unknown";
+    public string buildVersion = "unknown";
+    public string visitId = "unknown";
+    public string visitIdHash = "unknown";
+    public string userId = "unknown";
 }
 
 /// <summary>
-/// Helper class for tracking local changes to be transmitted to Server.
+/// Helper for tracking local changes pending transmission to Server.
 /// </summary>
 /// <see cref="UserData"/>
 public class UserDataWrapper {
-    public OutgoingAudioAPIData data { get; internal set; }
+    OutgoingAudioAPIData _data;
     public bool hasChanged { get; set; }
 
     public UserDataWrapper() {
-        data = new OutgoingAudioAPIData();
+        _data = new OutgoingAudioAPIData();
         hasChanged = false;
     }
 
     public Vector3 Position {
         set {
-            data.position = value;
+            _data.position = value;
             hasChanged = true;
         }
-        get { return data.position; }
+        get { return _data.position; }
     }
 
     public Quaternion Orientation {
         set {
-            data.orientation = value;
+            _data.orientation = value;
             hasChanged = true;
         }
-        get { return data.orientation; }
+        get { return _data.orientation; }
     }
 
     public float VolumeThreshold {
         set {
-            data.volumeThreshold = value;
+            _data.volumeThreshold = value;
             hasChanged = true;
         }
-        get { return data.volumeThreshold; }
+        get { return _data.volumeThreshold; }
     }
 
     public float Gain {
         set {
-            data.hiFiGain = value;
+            _data.hiFiGain = value;
             hasChanged = true;
         }
-        get { return data.hiFiGain; }
+        get { return _data.hiFiGain; }
     }
 
     public float Attenuation {
         set {
-            data.userAttenuation = value;
+            _data.userAttenuation = value;
             hasChanged = true;
         }
-        get { return data.userAttenuation; }
+        get { return _data.userAttenuation; }
     }
 
     public float Rolloff {
         set {
-            data.userRolloff = value;
+            _data.userRolloff = value;
             hasChanged = true;
         }
-        get { return data.userRolloff; }
+        get { return _data.userRolloff; }
+    }
+
+    public void SetOtherUserGain(string visitIdHash, float gain) {
+        if (!_data.otherUserGains.ContainsKey(visitIdHash)
+                || _data.otherUserGains[visitIdHash] != gain)
+        {
+            const float MIN_GAIN = 0.0f;
+            const float MAX_GAIN = 10.0f;
+            gain = System.Math.Min(System.Math.Max(gain, MIN_GAIN), MAX_GAIN);
+            _data.otherUserGains[visitIdHash] = gain;
+            hasChanged = true;
+        }
+    }
+
+    public OutgoingAudioAPIData GetDeepCopy() {
+        return _data.DeepCopy();
     }
 }
 
@@ -274,7 +290,7 @@ public class HiFiCommunicator : MonoBehaviour {
     /// The function signature for the PeerDisconnectedEvent
     /// </summary>
     /// <param name="ids">
-    /// A List of hashedVisitIds for all peers removed from the audio space since the last frame.
+    /// A List of visitIdHashes for all peers removed from the audio space since the last frame.
     /// </param>
     /// <see cref="PeerDisconnectedEvent"/>
     public delegate void OnPeerDisconnectedDelegate(SortedSet<string> ids);
@@ -302,6 +318,26 @@ public class HiFiCommunicator : MonoBehaviour {
     /// <see cref="UserDataWrapper"/>
     public UserDataWrapper UserData { get; internal set; }
 
+    /// <summary name=UserId>
+    /// The User's "provided user id" stored in the JWT used to connect to HiFi Spatial Audio Service.
+    /// </summary>
+    public string UserId {
+        set {}
+        get {
+            return _mixerInfo.userId;
+        }
+    }
+
+    /// <summary name=VisitIdHash>
+    /// A unique string for the User's connection to the HiFi Spatial Audio Service.
+    /// </summary>
+    public string VisitIdHash {
+        set {}
+        get {
+            return _mixerInfo.visitIdHash;
+        }
+    }
+
     HiFiMixerInfo _mixerInfo;
     Dictionary<string, IncomingAudioAPIData> _peerDataMap; // "peer key"-->IncomingAudioAPIData
     Dictionary<string, string> _peerKeyMap; // hashdVisitId-->"peer key"
@@ -326,6 +362,7 @@ public class HiFiCommunicator : MonoBehaviour {
     }
 
     void Awake() {
+        _mixerInfo = new HiFiMixerInfo();
         RaviUtil.InitializeWebRTC();
         const int MAX_UNCOMPRESSED_BUFFER_SIZE = 65536;
         _uncompressedData = new byte[MAX_UNCOMPRESSED_BUFFER_SIZE];
@@ -591,27 +628,25 @@ public class HiFiCommunicator : MonoBehaviour {
     /// <summary>
     /// Adjust the volume of a peer's audio for this user.
     /// </summary>
+    /// <remarks>
+    /// Setting the gain here has a delayed effect.  The "request" for the
+    /// change will be sent to the server in the next OutgoingAudioAPIData
+    /// update which travels over the webrtc "input" DataChannel.
+    /// (e.g. along with any position/orientation changes for the local user)
+    /// and the server will begin to apply volume adjustment on its end. There
+    /// will be no measure of success except the eventual effect on inbound
+    /// audio.
+    /// </remarks>
     /// <param name="visitIdHash">Unique string for target user.</param>
     /// <param name="gain">Float value in range [0,1].</param>
-    /// <returns>True if request was sent to HiFi Spatial Audio Service.</returns>
-    public bool SetOtherUserGainForThisConnection(string visitIdHash, float gain) {
+    public void SetOtherUserGainForThisConnection(string visitIdHash, float gain) {
         Log.Debug(this, "SendOtherUserGainForThisConnection id='{0}' gain={1}", visitIdHash, gain);
-        if (ConnectionState == AudionetConnectionState.Connected) {
-            JSONNode payload = new JSONObject();
-            payload["visit_id_hash"] = visitIdHash;
-            payload["gain"] = gain;
-            bool success = RaviSession.CommandController.SendCommand("audionet.personal_volume_adjust", payload);
-            if (!success) {
-                Log.Warning(this, "SEND audionet.personal_volume_adjust failed");
-            }
-            return success;
-        }
-        return false;
+        UserData.SetOtherUserGain(visitIdHash, gain);
     }
+
 
     void RemoveRaviSessionHandlers() {
         RaviSession.CommandController.RemoveCommandHandler("audionet.init");
-        RaviSession.CommandController.RemoveCommandHandler("audionet.personal_volume_adjust");
         RaviSession.CommandController.BinaryCommandHandler = null;
     }
 
@@ -780,7 +815,7 @@ public class HiFiCommunicator : MonoBehaviour {
         // BUG: Unity's webrtc plugin does not yet expose the ability to mute the mic
         // WORKAROUND: when muted we slam the hiFiGain and volumeThreshold submitted to the Server
         // to achieve server-side mute
-        OutgoingAudioAPIData data = UserData.data.DeepCopy();
+        OutgoingAudioAPIData data = UserData.GetDeepCopy();
         if (_muteMic) {
             data.hiFiGain = 0.0f;
             data.volumeThreshold = 0.0f;
@@ -878,11 +913,11 @@ public class HiFiCommunicator : MonoBehaviour {
                                 // used to indicate a peer has disconnected, so we maintain a Map
                                 // between these two keys to quickly figure out which peers are being
                                 // disconnected
-                                string hashedVisitId = peerInfo["e"];
-                                if (_peerKeyMap.ContainsKey(hashedVisitId)) {
-                                    _peerKeyMap[hashedVisitId] = key;
+                                string visitIdHash = peerInfo["e"];
+                                if (_peerKeyMap.ContainsKey(visitIdHash)) {
+                                    _peerKeyMap[visitIdHash] = key;
                                 } else {
-                                    _peerKeyMap.Add(hashedVisitId, key);
+                                    _peerKeyMap.Add(visitIdHash, key);
                                 }
                             }
                             somethingChanged = true;
@@ -897,13 +932,13 @@ public class HiFiCommunicator : MonoBehaviour {
                     JSONNode ids = obj["deleted_visit_ids"];
                     if (ids.IsArray) {
                         foreach (JSONNode id in ids) {
-                            string hashedVisitId = id.Value;
+                            string visitIdHash = id.Value;
                             string key;
-                            if (_peerKeyMap.TryGetValue(hashedVisitId, out key)) {
+                            if (_peerKeyMap.TryGetValue(visitIdHash, out key)) {
                                 _peerDataMap.Remove(key);
-                                _deletedVisitIds.Add(hashedVisitId);
+                                _deletedVisitIds.Add(visitIdHash);
                             }
-                            _peerKeyMap.Remove(hashedVisitId);
+                            _peerKeyMap.Remove(visitIdHash);
                         }
                     }
                     _peersHaveDisconnected = true;

--- a/Runtime/HiFiCommunicator.cs
+++ b/Runtime/HiFiCommunicator.cs
@@ -644,7 +644,6 @@ public class HiFiCommunicator : MonoBehaviour {
         UserData.SetOtherUserGain(visitIdHash, gain);
     }
 
-
     void RemoveRaviSessionHandlers() {
         RaviSession.CommandController.RemoveCommandHandler("audionet.init");
         RaviSession.CommandController.BinaryCommandHandler = null;

--- a/Samples~/Bumpers/Scripts/GameManager.cs
+++ b/Samples~/Bumpers/Scripts/GameManager.cs
@@ -113,7 +113,7 @@ public class GameManager : MonoBehaviour {
 
     void HandlePeerChanges(List<HiFi.IncomingAudioAPIData> peers) {
         foreach(HiFi.IncomingAudioAPIData peer in peers) {
-            string key = peer.hashedVisitID;
+            string key = peer.visitIdHash;
             OtherBumper other;
             // Note: transform from y-forward to z-forward
 #if USE_HIFI_COORDINATE_FRAME_UTIL
@@ -163,8 +163,8 @@ public class GameManager : MonoBehaviour {
 
     public void SetOtherGain(float gain) {
         foreach(KeyValuePair<string, OtherBumper> entry in _others) {
-            string hashedVisitId = entry.Key;
-            bool success = _communicator.SetOtherUserGainForThisConnection(hashedVisitId, gain);
+            string visitIdHash = entry.Key;
+            bool success = _communicator.SetOtherUserGainForThisConnection(visitIdHash, gain);
             break;
         }
     }

--- a/Samples~/TestHiFiCommunicator/Scenes.meta
+++ b/Samples~/TestHiFiCommunicator/Scenes.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6538ff8a59e87b0ebba934ded6981a25
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Samples~/TestHiFiCommunicator/Scenes/TestHiFiCommunicatorScene.unity
+++ b/Samples~/TestHiFiCommunicator/Scenes/TestHiFiCommunicatorScene.unity
@@ -1,0 +1,391 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 3
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 0
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 0
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 500
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 500
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 2
+    m_PVRDenoiserTypeDirect: 0
+    m_PVRDenoiserTypeIndirect: 0
+    m_PVRDenoiserTypeAO: 0
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 0
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 4890085278179872738, guid: 76213b9ffc9f508c0b6c823f934833f9, type: 2}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &519420028
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 519420032}
+  - component: {fileID: 519420031}
+  - component: {fileID: 519420029}
+  - component: {fileID: 519420030}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &519420029
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 519420028}
+  m_Enabled: 1
+--- !u!114 &519420030
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 519420028}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 79d7bd4750f386b4c8920df7874d77c6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  HiFiUrl: 
+  HiFiJwt: 
+  Position: {x: 0, y: 0, z: 0}
+  Orientation: {x: 0, y: 0, z: 0, w: 0}
+  _communicator: {fileID: 0}
+--- !u!20 &519420031
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 519420028}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 2
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 1
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 0
+  m_HDR: 1
+  m_AllowMSAA: 0
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 0
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &519420032
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 519420028}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &686362716
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 686362720}
+  - component: {fileID: 686362719}
+  - component: {fileID: 686362718}
+  - component: {fileID: 686362717}
+  m_Layer: 5
+  m_Name: Canvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &686362717
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 686362716}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &686362718
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 686362716}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
+--- !u!223 &686362719
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 686362716}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!224 &686362720
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 686362716}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
+--- !u!1 &1235698723
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1235698726}
+  - component: {fileID: 1235698725}
+  - component: {fileID: 1235698724}
+  m_Layer: 0
+  m_Name: EventSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1235698724
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1235698723}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4f231c4fb786f3946a6b90b886c48677, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalAxis: Horizontal
+  m_VerticalAxis: Vertical
+  m_SubmitButton: Submit
+  m_CancelButton: Cancel
+  m_InputActionsPerSecond: 10
+  m_RepeatDelay: 0.5
+  m_ForceModuleActive: 0
+--- !u!114 &1235698725
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1235698723}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FirstSelected: {fileID: 0}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 10
+--- !u!4 &1235698726
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1235698723}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Samples~/TestHiFiCommunicator/Scenes/TestHiFiCommunicatorScene.unity.meta
+++ b/Samples~/TestHiFiCommunicator/Scenes/TestHiFiCommunicatorScene.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2fda090e2423bbf4892e6f90ba556f29
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Samples~/TestHiFiCommunicator/Scripts.meta
+++ b/Samples~/TestHiFiCommunicator/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9f1c3bfbfe8765af59952c25a53ff40a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Samples~/TestHiFiCommunicator/Scripts/TestHiFiCommunicator.cs
+++ b/Samples~/TestHiFiCommunicator/Scripts/TestHiFiCommunicator.cs
@@ -1,0 +1,176 @@
+﻿// TestHiFiCommunicator.cs -- simple test/demo for HiFiCommunicator
+//
+
+using SimpleJSON;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class TestHiFiCommunicator : MonoBehaviour {
+
+    public string HiFiUrl;
+    public string HiFiJwt;
+    public Vector3 Position;
+    public Quaternion Orientation;
+    public HiFi.HiFiCommunicator _communicator;
+
+    private System.Diagnostics.Stopwatch _clock;
+    private float _orbitPeriod = 6.0f;
+    private float _orbitRadius = 1.0f;
+    private double _updateUserDataPeriod = 0.050;
+    private double _updateUserDataExpiry = 0.0;
+    private bool _muteTheMic = false;
+    private float _otherGain = 1.0f;
+    private Dictionary<string, HiFi.IncomingAudioAPIData> _knownPeers;
+
+    void Awake() {
+        Debug.Log("TestHiFiCommunicator.Awake");
+        _knownPeers = new Dictionary<string, HiFi.IncomingAudioAPIData>();
+
+        // create the Communicator
+        _communicator = gameObject.AddComponent<HiFi.HiFiCommunicator>() as HiFi.HiFiCommunicator;
+
+        // for this test we want to fail ASAP whenever there is a problem
+        // so we configure the retry/reconnect logic to not try hard
+        HiFi.HiFiConnectionAndTimeoutConfig config = new HiFi.HiFiConnectionAndTimeoutConfig();
+        config.AutoRetryConnection = false;
+        config.AutoReconnect = false;
+        _communicator.ConnectionConfig = config;
+
+        // register handlers for various _communicator events
+        _communicator.ConnectionStateChangedEvent += HandleHiFiConnectionStateChange;
+        _communicator.PeerDataUpdatedEvent += HandlePeerChanges;
+        _communicator.PeerDisconnectedEvent += HandlePeerDisconnects;
+
+        if (string.IsNullOrEmpty(HiFiUrl)) {
+            HiFiUrl = "wss://api.highfidelity.com:443/";
+        }
+        if (string.IsNullOrEmpty(HiFiJwt)) {
+            HiFiJwt = "get your own Java Web Token (JWT) from https://account.highfidelity.com/dev/account";
+        }
+
+        #if USE_HIFI_COORDINATE_FRAME_UTIL
+        // When using HiFiCoordinateFrameUtil we must compute the transforms once,
+        // before trying to use them.
+        HiFi.HiFiCoordinateFrameUtil.ComputeTransforms2D();
+        #endif
+    }
+
+    void Start() {
+        Debug.Log("TestHiFiCommunicator.Start");
+
+        // verify HiFiUrl and HiFiJwt
+        if (HiFiJwt == "get your own Java Web Token (JWT) from https://account.highfidelity.com/dev/account") {
+            Debug.Log("ERROR: this demo needs a valid JWT before it will work!");
+            QuitDemo();
+        }
+
+        // set misc Communicator config options
+        _communicator.SignalingServiceUrl = HiFiUrl;
+        _communicator.JWT = HiFiJwt;
+        _communicator.UserDataStreamingScope = HiFi.HiFiCommunicator.UserDataScope.All;
+
+        // start the communicator
+        _communicator.ConnectToHiFiAudioAPIServer();
+
+        // start the clock
+        _clock = new System.Diagnostics.Stopwatch();
+        _clock.Start();
+    }
+
+    void Update() {
+        if (Input.GetKeyUp(KeyCode.Escape) || Input.GetAxis("Cancel") > 0.0f) {
+            QuitDemo();
+        }
+        if (Input.GetKeyUp(KeyCode.M)) {
+            // toggle mute
+            _muteTheMic = !_muteTheMic;
+            _communicator.SetInputAudioMuted(_muteTheMic);
+        }
+        if (Input.GetKeyUp(KeyCode.G)) {
+            // toggle everyone else's gain between 1.0 and a smaller value
+            if (_otherGain == 1.0f) {
+                _otherGain = 0.2f;
+            } else {
+                _otherGain = 1.0f;
+            }
+            string my_key = _communicator.VisitIdHash;
+            foreach (string key in _knownPeers.Keys) {
+                if (key != my_key) {
+                    _communicator.SetOtherUserGainForThisConnection(key, _otherGain);
+                }
+            }
+        }
+    }
+
+    void FixedUpdate() {
+        double time = _clock.Elapsed.TotalSeconds;
+        if (time > _updateUserDataExpiry) {
+            ComputeNewPositionAndOrientation(time);
+            _updateUserDataExpiry = time + _updateUserDataPeriod;
+
+            // HiFi audio mixing expects movement in XZ plane,
+            // but Unity 2D motion is in XY, so we transform the axes
+            Vector3 p = Position;
+            Quaternion q = Orientation;
+            #if USE_HIFI_COORDINATE_FRAME_UTIL
+                // This is how to do it using HiFiCoordinateFrameUtil
+                _communicator.UserData.Position = HiFi.HiFiCoordinateFrameUtil.UnityPositionToHiFi(p);
+                _communicator.UserData.Orientation = HiFi.HiFiCoordinateFrameUtil.UnityOrientationToHiFi(q);
+            #else
+                // This is how to do it manually (and more efficiently)
+                // since all expected rotations are about the "up" axis
+                _communicator.UserData.Position = new Vector3(p.x, 0.0f, -p.y);
+                _communicator.UserData.Orientation = new Quaternion(0.0f, q.z, 0.0f, q.w);
+            #endif
+        }
+    }
+
+    void QuitDemo() {
+        _communicator.DisconnectFromHiFiAPIServer();
+        #if UNITY_EDITOR
+            // Application.Quit() does not work in the editor so
+            // UnityEditor.EditorApplication.isPlaying need to be set to false to end the game
+            UnityEditor.EditorApplication.isPlaying = false;
+        #else
+            Application.Quit();
+        #endif
+    }
+
+    void ComputeNewPositionAndOrientation(double time) {
+        // move the user in a circle about the origin
+        double theta = 2.0 * Math.PI * (time / (double)_orbitPeriod);
+        // default Unity 2D motion is in XY plane (e.g. Camera is looking along +Z-axis)
+        Position.x = _orbitRadius * (float)(Math.Sin(theta));
+        Position.y = _orbitRadius * (float)(Math.Cos(theta));
+        Position.z = 0.0f;
+        Orientation.Set(0.0f, 0.0f, 0.0f, 1.0f);
+    }
+
+    void HandleHiFiConnectionStateChange(HiFi.HiFiCommunicator.AudionetConnectionState state) {
+        // print the state to verify this method is being called
+        Debug.Log(string.Format("TestHiFiCommunicator.HandleHiFiConnectionStateChange state={0}", state));
+    }
+
+    void HandlePeerChanges(List<HiFi.IncomingAudioAPIData> peers) {
+        // this is where we harvest data about: new peers,
+        // and changes to known peers (e.g. volume, position, etc)
+        foreach (HiFi.IncomingAudioAPIData peer in peers) {
+            if (!_knownPeers.ContainsKey(peer.visitIdHash)) {
+                // this is a new peer
+                _knownPeers[peer.visitIdHash] = peer;
+            } else {
+                // this is an update to a known peer
+                _knownPeers[peer.visitIdHash] = peer;
+            }
+        }
+    }
+
+    void HandlePeerDisconnects(SortedSet<string> keys) {
+        // this is where forget about known peers who have left
+        foreach (string key in keys) {
+            _knownPeers.Remove(key);
+        }
+    }
+}

--- a/Samples~/TestHiFiCommunicator/Scripts/TestHiFiCommunicator.cs
+++ b/Samples~/TestHiFiCommunicator/Scripts/TestHiFiCommunicator.cs
@@ -159,6 +159,7 @@ public class TestHiFiCommunicator : MonoBehaviour {
         foreach (HiFi.IncomingAudioAPIData peer in peers) {
             if (!_knownPeers.ContainsKey(peer.visitIdHash)) {
                 // this is a new peer
+                Debug.Log(string.Format("TestHiFiCommunicator.HandlePeerChanges new user={0}", peer.visitIdHash));
                 _knownPeers[peer.visitIdHash] = peer;
             } else {
                 // this is an update to a known peer

--- a/Samples~/TestHiFiCommunicator/Scripts/TestHiFiCommunicator.cs.meta
+++ b/Samples~/TestHiFiCommunicator/Scripts/TestHiFiCommunicator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 79d7bd4750f386b4c8920df7874d77c6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,8 @@
+## v0.2.0
+* Fix for HiFiCommunicator.SetOtherUserGainForThisConnection()
+* HiFiCommunicator.SetOtherUserGainForThisConnection() now returns void instead of bool
+* Added simple TestHiFiCommunicator sample
+
+## v0.1.0
+* Plugin works using hacked (direct audio) version of official unity webrtc plugin
+

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.highfidelity.spatialized-audio",
   "displayName": "HiFi Spatialized Audio",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": {
     "name" : "High Fidelity",
     "url" : "http://highfidelity.com"

--- a/package.json
+++ b/package.json
@@ -16,13 +16,18 @@
   ],
   "dependencies": {
     "com.endel.nativewebsocket": "1.1.1",
-    "com.unity.webrtc": "2.4.0-exp.3"
+    "com.unity.webrtc": "2.4.0-directAudio"
   },
   "samples": [
     {
       "displayName": "Bumpers",
       "description": "A multi-user 2D app with 3D High Fidelity Audio spatialized to each user's 'dot', alongside background audio.",
       "path": "Samples~/Bumpers"
+    },
+    {
+      "displayName": "TestHiFiCommunicator",
+      "description": "A minimal zero-graphics demo for connecting to HiFi Spatial Audio service.",
+      "path": "Samples~/TestHiFiCommunicator"
     }
   ]
 }


### PR DESCRIPTION
This PR fixes a problem where `HiFiCommunicator.SetOtherUserGainForThisConnection()` was broken.  Other changes include:

- namechange all `hashedVisitId` to `visitIdHash`
- add `HiFiCommunicator.UserId` and `.VisitIdHash` properties
- add `TestHiFiCommunicator` example