### PR TITLE
init volumeThreshold to defer to default

### DIFF
--- a/Runtime/HiFiAudioAPIData.cs
+++ b/Runtime/HiFiAudioAPIData.cs
@@ -238,10 +238,10 @@ public class OutgoingAudioAPIData {
     public OutgoingAudioAPIData() {
         position = new Vector3(0.0f, 0.0f, 0.0f);
         orientation = new Quaternion(0.0f, 0.0f, 0.0f, 1.0f);
-        const float DEFAULT_VOLUME_THRESHOLD = -40.0f;
+        const float DEFAULT_VOLUME_THRESHOLD = Single.NaN; // NaN means "defer to server default"
         const float DEFAULT_HIFI_GAIN = 1.0f;
-        const float DEFAULT_USER_ATTENUATION = 0.0f; // 0.0 means "defer to server default"
-        const float DEFAULT_USER_ROLLOFF = 0.0f; // 0.0 means "defer to server default"
+        const float DEFAULT_USER_ATTENUATION = Single.NaN; // NaN means "defer to server default"
+        const float DEFAULT_USER_ROLLOFF = Single.NaN; // NaN means "defer to server default"
         volumeThreshold = DEFAULT_VOLUME_THRESHOLD;
         hiFiGain = DEFAULT_HIFI_GAIN;
         userAttenuation = DEFAULT_USER_ATTENUATION;;
@@ -314,7 +314,11 @@ public class OutgoingAudioAPIData {
             }
         }
 
-        if (volumeThreshold != other.volumeThreshold) {
+        bool param_is_nan = Single.IsNaN(volumeThreshold);
+        bool other_param_is_nan = Single.IsNaN(other.volumeThreshold);
+        if (param_is_nan != other_param_is_nan
+                || (!param_is_nan && volumeThreshold != other.volumeThreshold))
+        {
             changes.T = other.volumeThreshold;
             volumeThreshold = other.volumeThreshold;
         }
@@ -324,12 +328,20 @@ public class OutgoingAudioAPIData {
             hiFiGain = other.hiFiGain;
         }
 
-        if (userAttenuation != other.userAttenuation) {
+        param_is_nan = Single.IsNaN(userAttenuation);
+        other_param_is_nan = Single.IsNaN(other.userAttenuation);
+        if (param_is_nan != other_param_is_nan
+                || (!param_is_nan && userAttenuation != other.userAttenuation))
+        {
             changes.a = other.userAttenuation;
             userAttenuation = other.userAttenuation;
         }
 
-        if (userRolloff != other.userRolloff) {
+        param_is_nan = Single.IsNaN(userRolloff);
+        other_param_is_nan = Single.IsNaN(other.userRolloff);
+        if (param_is_nan != other_param_is_nan
+                || (!param_is_nan && userRolloff != other.userRolloff))
+        {
             changes.r = other.userRolloff;
             userRolloff = other.userRolloff;
         }

--- a/Runtime/HiFiCommunicator.cs
+++ b/Runtime/HiFiCommunicator.cs
@@ -376,7 +376,7 @@ public class HiFiCommunicator : MonoBehaviour {
         // update is actually sent (e.g. because we only send changes ==> force first update).
         _lastUserData.position = new Vector3(-1.0e7f, -1.0e7f, -1.0e7f);
         _lastUserData.orientation = new Quaternion(-1.0e7f, -1.0e7f, -1.0e7f, -1.0e7f);
-        _lastUserData.volumeThreshold = -96.0f;
+        //_lastUserData.volumeThreshold = -96.0f; // don't twiddle this one
         _lastUserData.hiFiGain = -1.0e7f;
         //_lastUserData.userAttenuation = -1.0e7f; // don't twiddle this one
         //_lastUserData.userRolloff = -1.0e7f; // don't twiddle this one

--- a/Samples~/TestHiFiCommunicator/Scripts/TestHiFiCommunicator.cs
+++ b/Samples~/TestHiFiCommunicator/Scripts/TestHiFiCommunicator.cs
@@ -24,6 +24,7 @@ public class TestHiFiCommunicator : MonoBehaviour {
     private float _otherGain = 1.0f;
     private bool _useDefaultAttenuation = true;
     private bool _useDefaultRolloff = true;
+    private bool _useDefaultVolumeThreshold = true;
     private Dictionary<string, HiFi.IncomingAudioAPIData> _knownPeers;
 
     void Awake() {
@@ -91,6 +92,7 @@ public class TestHiFiCommunicator : MonoBehaviour {
         // G = toggle gain of peers between 1.0 and 0.2
         // Z = toggle user Attenuation between 0.0001 and "defer to default" (aka 0.5)
         // X = toggle user Rolloff between 5.0 and "defer to default" (aka 16.0)
+        // C = toggle user volumeThreshold between -5.0 and "defer to default" (aka -40)
         //
         if (Input.GetKeyUp(KeyCode.M)) {
             // toggle mute
@@ -125,6 +127,14 @@ public class TestHiFiCommunicator : MonoBehaviour {
                 _communicator.UserData.Rolloff = Single.NaN;
             } else {
                 _communicator.UserData.Rolloff = 5.0f;
+            }
+        }
+        if (Input.GetKeyUp(KeyCode.C)) {
+            _useDefaultVolumeThreshold = !_useDefaultVolumeThreshold;
+            if (_useDefaultVolumeThreshold) {
+                _communicator.UserData.VolumeThreshold = Single.NaN;
+            } else {
+                _communicator.UserData.VolumeThreshold = -5.0f;
             }
         }
     }


### PR DESCRIPTION
When auditing how **volumeThreshold** works in the Unity client I decided it needed some changes.